### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ Tortosa has a first released version 1.0 which compiles only with the version of
     > vte3-devel
 
 +    Debian: 
-    > libgtk-3-0-dev
-    > libvte-2.90-dev
+    > libvte-2.91-dev
 
 ##Installation
 


### PR DESCRIPTION
Fixed the readme for installing on debian.  libvte was using the wrong version and libgtk had the wrong name entirely.  Since libgtk is a dependency of libvte I removed it entirely.
